### PR TITLE
Add cryptography dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ openpyxl==3.1.2
 flask-cors==4.0.0
 xlsxwriter==3.1.9
 requests==2.31.0
+cryptography>=41.0.0


### PR DESCRIPTION
## Summary
- include cryptography>=41.0.0 in requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy<2 — proxy 403)*
- `python app.py` *(fails: ValueError: numpy.dtype size changed, may indicate binary incompatibility)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68b47abd43548329a36b9013e244a407